### PR TITLE
Keep original value for primitive-like strings

### DIFF
--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -16,13 +16,20 @@ describe("library", () => {
 
     const expected = 100;
     placeHolderReplacer.addVariableMap({
-      key: expected,
+      key: 100,
+      numstring: "101",
     });
     const afterReplace: any = placeHolderReplacer.replace({
       replaceable: "{{key}}",
+      y: "{{numstring}}",
+      x: "4.0",
+      z: 8,
     });
 
     expect(afterReplace.replaceable).toBe(expected);
+    expect(afterReplace.y).toBe("101");
+    expect(afterReplace.x).toBe("4.0");
+    expect(afterReplace.z).toBe(8);
   });
 
   it("should replace placeholder <<>>", () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -11,6 +11,32 @@ describe("library", () => {
     ).not.toThrow();
   });
 
+  it("should keep original values", () => {
+    const placeHolderReplacer = new JsonPlaceholderReplacer();
+
+    const afterReplace: any = placeHolderReplacer.replace({
+      stringFloat: "4.0",
+      stringInt: "7",
+      stringBoolean: "true",
+      boolTrue: true,
+      boolFalse: false,
+      numberInt: 8,
+      numberFloat: 8.123,
+      nullNull: null,
+      stringNull: "null",
+    });
+
+    expect(afterReplace.stringFloat).toBe("4.0");
+    expect(afterReplace.stringInt).toBe("7");
+    expect(afterReplace.stringBoolean).toBe("true");
+    expect(afterReplace.boolTrue).toBe(true);
+    expect(afterReplace.boolFalse).toBe(false);
+    expect(afterReplace.numberInt).toBe(8);
+    expect(afterReplace.numberFloat).toBe(8.123);
+    expect(afterReplace.nullNull).toBeNull();
+    expect(afterReplace.stringNull).toBe("null");
+  });
+
   it("should replace placeholder {{}}", () => {
     const placeHolderReplacer = new JsonPlaceholderReplacer();
 
@@ -22,14 +48,10 @@ describe("library", () => {
     const afterReplace: any = placeHolderReplacer.replace({
       replaceable: "{{key}}",
       y: "{{numstring}}",
-      x: "4.0",
-      z: 8,
     });
 
     expect(afterReplace.replaceable).toBe(expected);
     expect(afterReplace.y).toBe("101");
-    expect(afterReplace.x).toBe("4.0");
-    expect(afterReplace.z).toBe(8);
   });
 
   it("should replace placeholder <<>>", () => {

--- a/src/library.ts
+++ b/src/library.ts
@@ -86,13 +86,14 @@ export class JsonPlaceholderReplacer {
       if (typeof attribute === "object") {
         node[key] = this.replaceChildren(attribute);
       } else if (attribute !== undefined) {
-        node[key] = this.replaceValue(attribute.toString());
+        node[key] = this.replaceValue(attribute);
       }
     }
     return node;
   }
 
-  private replaceValue(node: string): string {
+  private replaceValue(node: any): string {
+    const attributeAsString = node.toString();
     const placeHolderIsInsideStringContext =
       !this.delimiterTagsRegex.test(node);
     const output = this.configuration.delimiterTags.reduce(
@@ -106,9 +107,12 @@ export class JsonPlaceholderReplacer {
           this.replacer(placeHolderIsInsideStringContext)(delimiterTag),
         );
       },
-      node,
+      attributeAsString,
     );
     try {
+      if (output === attributeAsString) {
+        return node;
+      }
       return JSON.parse(output);
     } catch (exc) {
       return output;


### PR DESCRIPTION
When original value is a string that "contains" a literal value (number, boolean etc) it should not be transformed to an actual literal - but kept as a string when no transformation takes place.
A version of this is discussed in #18 but is not addressed completely.