### PR TITLE
Add nullishValues option, fix variablesMap traverse

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged
 npm test

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 tsconfig.json
 tslint.json
-tslint.json
 rep
 map
 README.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 
 .gitignore
 .prettierignore
+.npmignore

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ const afterReplace = placeHolderReplacer.replace({
 // }
 ```
 
+> [!NOTE]
+> An object passed to `.replace()` is mutated in-place:
+>
+> ```ts
+> const beforeReplace = { some: "object" };
+> const afterReplace = placeHolderReplacer.replace(beforeReplace);
+> // beforeReplace === afterReplace
+> ```
+
 ### You can replace the default placeholders with some as cool as you want
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const afterReplace = placeHolderReplacer.replace({
 > An object passed to `.replace()` is mutated in-place:
 >
 > ```ts
-> const beforeReplace = { some: "object" };
+> const beforeReplace = { some: "{{placeholder}}" };
 > const afterReplace = placeHolderReplacer.replace(beforeReplace);
 > // beforeReplace === afterReplace
 > ```

--- a/README.md
+++ b/README.md
@@ -105,21 +105,69 @@ const afterReplace = placeHolderReplacer.replace({
 // }
 ```
 
-### And the last added maps have higher priority, so
+### And the last added maps have higher priority (but non-nullish values will be preserved from previous map)
 
 ```typescript
 placeHolderReplacer.addVariableMap({
   id: "lowerPriority",
+  name: "Name",
 });
 placeHolderReplacer.addVariableMap({
   id: "higherPriority",
+  name: undefined,
 });
 const afterReplace = placeHolderReplacer.replace({
-  replaceable: "{{id}}",
+  id: "{{id}}",
+  name: "{{name}}",
 });
 
 // afterReplace = {
-//    replaceable: "higherPriority"
+//    id: "higherPriority"
+//    name: "Name"
+// }
+```
+
+### It's possible to override global values map with `.setVariableMap()`
+
+```typescript
+placeHolderReplacer.addVariableMap({
+  id: "Id",
+  name: "Name",
+});
+placeHolderReplacer.setVariableMap({
+  // <- note setVariableMap() here
+  id: "New Id",
+  name: undefined,
+});
+const afterReplace = placeHolderReplacer.replace({
+  id: "{{id}}",
+  name: "{{name}}",
+});
+
+// afterReplace = {
+//    id: "New Id"
+//    name: "{{name}}"
+// }
+```
+
+### It's possible to override global maps with local by `.replaceWith()`
+
+```typescript
+placeHolderReplacer.addVariableMap({
+  id: "Id",
+  name: "Name",
+});
+const afterReplace = placeHolderReplacer.replaceWith(
+  {
+    id: "{{id}}",
+    name: "{{name}}",
+  },
+  { name: "New Name" },
+);
+
+// afterReplace = {
+//    id: "{{id}}"
+//    name: "New Name"
 // }
 ```
 
@@ -171,19 +219,17 @@ const afterReplace = placeHolderReplacer.replace({
 
 ```typescript
 placeHolderReplacer.addVariableMap({
-    key: 987,
-    objectReplaceable: {
-      inner: "inner"
-    }
+  key: 987,
+  objectReplaceable: {
+    inner: "inner",
+  },
 });
 const afterReplace = placeHolderReplacer.replace({
-    array: ["string", "{{objectReplaceable}}", {{key}}]
-})
+  array: ["string", "{{objectReplaceable}}", "{{key}}"],
+});
 
 // afterReplace = {
-//    array: ["string", {
-//                        inner: "inner"
-//                      }, 987]
+//    array: ["string", { inner: "inner" }, 987]
 // }
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "json-placeholder-replacer",
   "version": "2.0.5",
   "description": "Javascript/Typescript library/cli to replace placeholders in an javascript object",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/library.js",
+  "types": "dist/library.d.ts",
   "scripts": {
     "test": "node_modules/.bin/jest",
     "codeCoverage": "node_modules/.bin/jest --silent --coverage",

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -202,6 +202,21 @@ describe("library", () => {
     ).toStrictEqual({ key1: "{{key1}}", key2: "someKey2", key3: "someKey3" });
   });
 
+  it("should mutate passed objects in place on replacement", () => {
+    const placeHolderReplacer = new JsonPlaceholderReplacer();
+
+    placeHolderReplacer.addVariableMap({ key: "someKey" });
+
+    const object = { key: "{{key}}", some: true };
+    const array = [false, "{{key}}"];
+
+    const afterReplaceObject = placeHolderReplacer.replace(object);
+    const afterReplaceArray = placeHolderReplacer.replace(array);
+
+    expect(afterReplaceObject).toEqual(object);
+    expect(afterReplaceArray).toEqual(array);
+  });
+
   it("should accept default values with separator", () => {
     const defaultValue = "default-value";
     const placeHolderReplacer = new JsonPlaceholderReplacer();

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -202,6 +202,23 @@ describe("library", () => {
     ).toStrictEqual({ key1: "{{key1}}", key2: "someKey2", key3: "someKey3" });
   });
 
+  it("should work with local variableMap", () => {
+    const placeHolderReplacer = new JsonPlaceholderReplacer();
+
+    placeHolderReplacer.addVariableMap({ key1: "someKey1" });
+
+    expect(
+      placeHolderReplacer.replaceWith({ key1: "{{key1}}", key2: "{{key2}}" }),
+    ).toStrictEqual({ key1: "{{key1}}", key2: "{{key2}}" });
+
+    expect(
+      placeHolderReplacer.replaceWith(
+        { key1: "{{key1}}", key2: "{{key2}}" },
+        { key2: "someKey2" },
+      ),
+    ).toStrictEqual({ key1: "{{key1}}", key2: "someKey2" });
+  });
+
   it("should mutate passed objects in place on replacement", () => {
     const placeHolderReplacer = new JsonPlaceholderReplacer();
 

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -165,24 +165,44 @@ describe("library", () => {
     expect(afterReplace.replaceable).toBe(expected);
   });
 
-  it("last added map should have higher priority", () => {
+  it("last added map should have higher priority, but preserve value from previous map", () => {
     const placeHolderReplacer = new JsonPlaceholderReplacer();
 
-    const expected = 100;
     placeHolderReplacer.addVariableMap({
       key: "useless",
+      key2: "handy",
     });
     placeHolderReplacer.addVariableMap({
-      key: expected,
+      key: 100,
     });
     const afterReplace: any = placeHolderReplacer.replace({
       replaceable: "{{key}}",
+      replaceable2: "{{key2}}",
     });
 
-    expect(afterReplace.replaceable).toBe(expected);
+    expect(afterReplace.replaceable).toBe(100);
+    expect(afterReplace.replaceable2).toBe("handy");
   });
 
-  it("should acceptd default values with separator", () => {
+  it("should overwrite variableMap", () => {
+    const placeHolderReplacer = new JsonPlaceholderReplacer();
+
+    placeHolderReplacer.addVariableMap({ key1: "someKey1" });
+    placeHolderReplacer.setVariableMap(
+      { key3: { deep: "someKey3" } },
+      { key2: "someKey2" },
+    );
+
+    expect(
+      placeHolderReplacer.replace({
+        key1: "{{key1}}",
+        key2: "{{key2}}",
+        key3: "{{key3.deep}}",
+      }),
+    ).toStrictEqual({ key1: "{{key1}}", key2: "someKey2", key3: "someKey3" });
+  });
+
+  it("should accept default values with separator", () => {
     const defaultValue = "default-value";
     const placeHolderReplacer = new JsonPlaceholderReplacer();
 
@@ -208,6 +228,54 @@ describe("library", () => {
     });
 
     expect(afterReplace.replaceable).toBe(expected);
+  });
+
+  it("should be able to set values which should be treated as nullish to replace with default value", () => {
+    const defaultValue = "default";
+    const variables = {
+      null: null,
+      empty: "",
+      false: false,
+      number: 0,
+    };
+
+    const placeHolderReplacer = new JsonPlaceholderReplacer({
+      nullishValues: [null, "", false, 0],
+    });
+
+    placeHolderReplacer.addVariableMap(variables);
+
+    expect(
+      placeHolderReplacer.replace({
+        undefined: `{{undefined:${defaultValue}}}`,
+        null: `{{null:${defaultValue}}}`,
+        empty: `{{empty:${defaultValue}}}`,
+        false: `{{false:${defaultValue}}}`,
+        number: `{{number:${defaultValue}}}`,
+      }),
+    ).toStrictEqual({
+      undefined: defaultValue,
+      empty: defaultValue,
+      false: defaultValue,
+      null: defaultValue,
+      number: defaultValue,
+    });
+
+    expect(
+      placeHolderReplacer.replace({
+        undefined: `{{undefined}}`,
+        null: `{{null}}`,
+        empty: `{{empty}}`,
+        false: `{{false}}`,
+        number: `{{number}}`,
+      }),
+    ).toStrictEqual({
+      undefined: `{{undefined}}`,
+      null: `{{null}}`,
+      empty: `{{empty}}`,
+      false: `{{false}}`,
+      number: `{{number}}`,
+    });
   });
 
   it("should be able to change default value separator", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -15,10 +15,11 @@
     "no-var-requires": true,
     "no-require-imports": true,
     "one-line": [true, "check-else", "check-whitespace", "check-open-brace"],
-    "quotemark": [true, "single", "avoid-escape"],
+    "quotemark": [true, "double", "avoid-escape"],
     "semicolon": [true, "always"],
     "typedef-whitespace": [
-      true, {
+      true,
+      {
         "call-signature": "nospace",
         "index-signature": "nospace",
         "parameter": "nospace",


### PR DESCRIPTION
### Changes made
- **Add `nullishValues` option to set values**

  Currently, only `undefined` variable will tell placeholder`{{key:defaultValue}}` to use defaultValue instead of itself.
  But usually we may want to treat some values as `undefined` (like `null` or empty string, for example) just to replace it with something default.
  
  New `nullishValues` option accepts array of primitives, which will be treated as undefined values:
  ```ts
  new JsonPlaceholderReplacer({ nullishValues: [null, "", false, 0, "or even some string"] });
  ```

- **Add `setVariableMap()` public method**

  Currently, calling `addVariableMap()` will add every new item to internal `variablesMap` array.
  This is caused the main inconvenience of plugin usage: we cannot use `JsonPlaceholderReplacer` instance created globally without memory leaking: all values are preserved.
  Another point is that adding values have no practical sense: only last one is used with current implementation.
  
  That behaviour looks like an issue: I can expect previously added `variableMap` should be used in case key is undefined in last the last added map. 
  Based on all above, following changes are proposed:
    - new `setVariableMap()` method, which accepts multiple args and overwrites internal `variablesMap` array with maps in order they passed:
      ```ts
      setVariableMap(...variablesMap: (Record<string, unknown> | string)[])
      ``` 
    - fix internal `checkInEveryMap()` method to use the last non-nullish value found (taking into account new `nullishValues` option).
       That means: having `variablesMap: [{ key1: 1 }, { key2: 2}]` placeholder `{{key1}}` will have a value `1`, but not `undefined` like before.

- **Add `replaceWith()` public method**
   While `setVariableMap()` redefines variable maps globally, `replaceWith()` will ignore global maps in favor of locally passed ones. So this is just an extended version of `.replace()` method:
   ```ts
   replaceWith(json: object, ...variablesMap: VariableMap[])
   ```

- **Update readme, add unit tests to cover changes above**

- **Fix main entry point**
   The plugin entry point was `dist/index.js`, which is cli script. Using that in browser builds are impossible. Correct export should be `dist/library.js`

### Minor dev changes
- fix `husky` configuration to work with its newer version used in project
- fix `tslint` config to work with double quotes used in project
- fix `prettier` config